### PR TITLE
Delete UI

### DIFF
--- a/app/controllers/expense_logs_controller.rb
+++ b/app/controllers/expense_logs_controller.rb
@@ -79,8 +79,9 @@ module Controllers
     def validate_params(payload)
       errs = []
       errs << "title は必須で、文字列である必要があります。" if payload[:title].to_s.strip.empty?
-      errs << "amount は必須で、0以上の整数である必要があります。" unless payload[:amount].is_a?(Integer) && payload[:amount] >= 0
-      errs << "date は必須で、YYYY-MM-DD形式である必要があります。" unless payload[:date]&.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+      unless payload[:amount].is_a?(Integer) && payload[:amount] >= 0
+        errs << "amount は必須で、0以上の整数である必要があります。"
+      end
       errs
     end
 
@@ -101,7 +102,7 @@ module Controllers
       false
     end
     
-    def save_expense_log(res, title, amount, date_str)
+    def save_expense_log(res, title, amount, date_str = nil)
       if date_str.to_s.strip.empty?
         sql  = <<~SQL
           INSERT INTO expense_logs (title, amount, date, created_at)

--- a/public/details.js
+++ b/public/details.js
@@ -335,10 +335,49 @@ class DetailsApp {
             if (confirm('この学習記録を削除しますか？')) {
                 await this.deleteStudy(id);
             }
-        } else if (type === 'category' || type === 'task') {
-            // TODO: 共通化されたカテゴリ・タスク削除処理を呼び出す
-            console.log(`${type} "${name}" の削除は後で実装予定`);
-            alert('カテゴリ・タスクの削除機能は準備中です');
+        } else if (type === 'category') {
+            if (confirm(`カテゴリ「${name}」を削除しますか？`)) {
+                this.deleteCategory(name);
+            }
+        } else if (type === 'task') {
+            if (confirm(`タスク「${name}」を削除しますか？`)) {
+                this.deleteTask(name);
+            }
+        }
+    }
+
+    // カテゴリ・タスク削除機能を復活
+    deleteCategory(name) {
+        const categoryItem = document.querySelector(`[data-category="${name}"]`);
+        if (categoryItem) {
+            categoryItem.remove();
+            if (this.state.selectedCategory === name) {
+                // 最初のカテゴリを選択
+                const firstCategory = document.querySelector('.category-item');
+                if (firstCategory) {
+                    firstCategory.classList.add('active');
+                    this.state.selectedCategory = firstCategory.dataset.category;
+                } else {
+                    this.state.selectedCategory = null;
+                }
+            }
+        }
+    }
+
+    deleteTask(name) {
+        const taskItem = document.querySelector(`[data-task="${name}"]`);
+        if (taskItem) {
+            taskItem.remove();
+            if (this.state.selectedTask === name) {
+                // 最初のタスクを選択
+                const firstTask = document.querySelector('.task-item');
+                if (firstTask) {
+                    firstTask.classList.add('active');
+                    this.state.selectedTask = firstTask.dataset.task;
+                } else {
+                    this.state.selectedTask = null;
+                }
+            }
         }
     }
 
@@ -362,29 +401,6 @@ class DetailsApp {
             alert(`削除中にエラーが発生しました: ${error.message}`);
         }
     }
-
-    // カテゴリ・タスクの削除は共通化予定のため一時的にコメントアウト
-    /*
-    deleteCategory(name) {
-        const categoryItem = document.querySelector(`[data-category="${name}"]`);
-        if (categoryItem) {
-            categoryItem.remove();
-            if (this.state.selectedCategory === name) {
-                this.state.selectedCategory = null;
-            }
-        }
-    }
-
-    deleteTask(name) {
-        const taskItem = document.querySelector(`[data-task="${name}"]`);
-        if (taskItem) {
-            taskItem.remove();
-            if (this.state.selectedTask === name) {
-                this.state.selectedTask = null;
-            }
-        }
-    }
-    */
 
     editExpenseItem(index) {
         Object.assign(this.state, {
@@ -532,7 +548,7 @@ class DetailsApp {
             let result;
             const payload = { 
                 title: this.state.selectedTask, 
-                duration: durationSeconds * 1000,
+                duration: durationSeconds,
                 date: this.state.currentDate
             };
             
@@ -540,12 +556,7 @@ class DetailsApp {
                 result = await ApiClient.post('/api/study_logs', payload);
             } else if (this.state.editingStudyIndex !== null) {
                 const study = this.state.studies[this.state.editingStudyIndex];
-                const patchPayload = {
-                    title: this.state.selectedTask,
-                    duration: durationSeconds,
-                    date: this.state.currentDate
-                };
-                result = await ApiClient.patch(`/api/study_logs/${study.id}`, patchPayload);
+                result = await ApiClient.patch(`/api/study_logs/${study.id}`, payload);
             } else {
                 return alert("操作モードが不明です。");
             }

--- a/public/details.js
+++ b/public/details.js
@@ -213,11 +213,32 @@ class DetailsApp {
         this.setupEventListeners();
         await this.loadDailyData();
         
+        // 既存のカテゴリ・タスクに削除ボタンを追加
+        this.addDeleteButtonsToExistingItems();
+        
         // 初期状態で新規登録モードに設定
         this.startNewExpenseMode();
         this.startNewStudyMode();
         Dom.$('#addExpenseItemButton')?.classList.add('selected');
         Dom.$('#addStudyItemButton')?.classList.add('selected');
+    }
+
+    addDeleteButtonsToExistingItems() {
+        Dom.$$('.category-item').forEach(item => {
+            if (!item.querySelector('.delete-btn')) {
+                item.style.position = 'relative';
+                const name = item.dataset.category;
+                item.innerHTML += `<button class="delete-btn" data-type="category" data-name="${name}" title="削除"><img src="/trash-icon.svg" alt="削除" width="14" height="14"></button>`;
+            }
+        });
+
+        Dom.$$('.task-item').forEach(item => {
+            if (!item.querySelector('.delete-btn')) {
+                item.style.position = 'relative';
+                const name = item.dataset.task;
+                item.innerHTML += `<button class="delete-btn" data-type="task" data-name="${name}" title="削除"><img src="/trash-icon.svg" alt="削除" width="14" height="14"></button>`;
+            }
+        });
     }
     
     async loadDailyData() {

--- a/public/main.css
+++ b/public/main.css
@@ -474,3 +474,47 @@ html {
     color: #bbb;
     background-color: #bbbbbb49;
 }
+
+.category-item, .task-item {
+    position: relative;
+    padding: 10px 15px;
+    margin-bottom: 8px;
+    border-radius: 10px;
+    cursor: pointer;
+    text-align: center;
+    font-weight: 500;
+    color: #4a5568;
+}
+
+.delete-btn {
+    position: absolute;
+    right: 5px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(255, 71, 87, 0.7);
+    border: none;
+    border-radius: 50%;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+    z-index: 100;
+}
+
+.delete-btn img {
+    filter: brightness(0) invert(1); /* 白色にする */
+    pointer-events: none; /* imgへのクリックイベントを無効化 */
+}
+
+.delete-btn:hover {
+    background: rgba(255, 55, 66, 1);
+}
+
+/* hover時に削除ボタンを表示 */
+.category-item:hover .delete-btn,
+.task-item:hover .delete-btn {
+    display: flex;
+}


### PR DESCRIPTION
プルリク概要
	•	支出登録 API の date 処理を改善
	•	POST 時に payload[:date] が渡されていればその日付を、なければ CURDATE()（サーバー日付）を使ってレコードを作成
	•	詳細ページ（URL の ?date=）／トップページ（当日付）それぞれで正しい日付が扱われるように
	•	カテゴリ・タスクの削除機能を追加
	•	カテゴリ・タスク一覧に “×” ボタンを設置

⸻
動作確認
	1.	支出登録
	•	トップページ（/） → 今日付で登録
	•	詳細ページ（/details.html?date=YYYY-MM-DD） → 指定日で登録
	2.	カテゴリ／タスク削除
	•	詳細画面、トップページのカテゴリ・タスクにマウスオーバー → “×” が表示 → 押下 → 確認ダイアログ → 削除
⸻

以上よろしくお願いします！